### PR TITLE
fix: wrong type definition path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "RTMP live streaming library from api.video",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
Hey,

currently types aren't available as path is different after v2.0.0. 
This fixes the path to correct one, but you may also want to tweak the config in a different way.