### PR TITLE
fix(ios): Update Swift header import path for New Architecture compatibility

### DIFF
--- a/ios/RNLiveStreamView.mm
+++ b/ios/RNLiveStreamView.mm
@@ -13,8 +13,8 @@
 
 
 // MARK: Swift classes in ObjC++
-#if __has_include("react-native-livestream/react_native_livestream-Swift.h")
-#import "react-native-livestream/react_native_livestream-Swift.h"
+#if __has_include(<react_native_livestream/react_native_livestream-Swift.h>)
+#import <react_native_livestream/react_native_livestream-Swift.h>
 #else
 #import "react_native_livestream-Swift.h"
 #endif


### PR DESCRIPTION
## Issue
 ✅ Build works fine with New Architecture disabled
- `ios/Podfile`
``` ruby
  use_react_native!(
    :path => config[:reactNativePath],
    # An absolute path to your application root.
    :app_path => "#{Pod::Config.instance.installation_root}/..",
    :hermes_enabled => true,
    :fabric_enabled => false,
    :new_arch_enabled => false 
  )
```

❌ Build fails with New Architecture enabled (see screenshots in linked issues)
- `ios/Podfile`
``` ruby
  use_react_native!(
    :path => config[:reactNativePath],
    # An absolute path to your application root.
    :app_path => "#{Pod::Config.instance.installation_root}/..",
    :hermes_enabled => true,
    :fabric_enabled => true,
    :new_arch_enabled => true 
  )
```

<img width="1214" height="827" alt="Screenshot 2025-10-01 at 3 19 56 PM" src="https://github.com/user-attachments/assets/46676d0d-fd52-4246-a5ee-466bea8d80c5" />


## Issue Links
- https://github.com/apivideo/api.video-reactnative-live-stream/issues/100
- https://github.com/apivideo/api.video-reactnative-live-stream/issues/107